### PR TITLE
fix: use `findExportNames` to add auto-imports from core modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@tresjs/core": "^2.1.2",
     "@tresjs/post-processing": "^0.2.0",
     "@types/three": "^0.152.1",
+    "mlly": "^1.3.0",
     "pkg-types": "^1.0.3",
     "three": "^0.153.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@nuxt/kit':
     specifier: ^3.5.2
@@ -16,6 +20,9 @@ dependencies:
   '@types/three':
     specifier: ^0.152.1
     version: 0.152.1
+  mlly:
+    specifier: ^1.3.0
+    version: 1.3.0
   pkg-types:
     specifier: ^1.0.3
     version: 1.0.3
@@ -8334,7 +8341,3 @@ packages:
   /zstddec@0.0.2:
     resolution: {integrity: sha512-DCo0oxvcvOTGP/f5FA6tz2Z6wF+FIcEApSTu0zV5sQgn9hoT5lZ9YRAKUraxt9oP7l4e8TnNdi8IZTCX6WCkwA==}
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
resolves https://github.com/Tresjs/nuxt/issues/5
resolves #6