### PR TITLE
fix: expose context state from TresCanvas to client only version

### DIFF
--- a/src/runtime/components/TresCanvas.vue
+++ b/src/runtime/components/TresCanvas.vue
@@ -1,11 +1,20 @@
 <script setup lang="ts">
 import { TresCanvas as TC, TresCanvasProps } from '@tresjs/core';
 defineProps<TresCanvasProps>()
+
+const stateRef = ref()
+
+defineExpose({
+  state: stateRef
+})
 </script>
 
 <template>
   <ClientOnly>
-    <TC v-bind="$props">
+    <TC
+      ref="stateRef"
+      v-bind="$props"
+    >
       <slot />
     </TC>
   </ClientOnly>


### PR DESCRIPTION
The client-only wrapper was isolating the ref to access the state.