### PR TITLE
fix: respect existing `isCustomElement` config in `vue.compilerOptions`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -89,8 +89,6 @@ export default defineNuxtModule<ModuleOptions>({
       return (typeof isCustomElement === 'function' && isCustomElement(tag)) || templateCompilerOptions.template.compilerOptions.isCustomElement(tag)
     }
 
-    nuxt.options.vue.compilerOptions.isCustomElement = templateCompilerOptions.template.compilerOptions.isCustomElement
-
     const allDeps = await getAllPackageDeps(nuxt.options.rootDir)
     const coreDeps = Object.keys(allDeps).filter(d => d.startsWith('@tresjs/'))
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -82,6 +82,13 @@ export default defineNuxtModule<ModuleOptions>({
       references.push({ types: '@tresjs/core' })
     })
 
+
+    const { isCustomElement } = nuxt.options.vue.compilerOptions
+
+    nuxt.options.vue.compilerOptions.isCustomElement = (tag: string) => {
+      return (typeof isCustomElement === 'function' && isCustomElement(tag)) || templateCompilerOptions.template.compilerOptions.isCustomElement(tag)
+    }
+
     nuxt.options.vue.compilerOptions.isCustomElement = templateCompilerOptions.template.compilerOptions.isCustomElement
 
     const allDeps = await getAllPackageDeps(nuxt.options.rootDir)


### PR DESCRIPTION
Currently, the module will overwrite any existing `vue.compilerOptions.isCustomElement` function defined in `nuxt.config.ts`.

This PR simply updates the module to capture any existing function definition, and use it in conjunction with the function provided by `templateCompilerOptions` when evaluating `isCustomElement`.